### PR TITLE
Changed booleans to have the v: flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ require('moonlight').set()
 
 ```vim
 " Example config in Vim-Script
-let g:moonlight_italic_comments = true
-let g:moonlight_italic_keywords = true
-let g:moonlight_italic_functions = true
-let g:moonlight_italic_variables = false
-let g:moonlight_contrast = true
-let g:moonlight_borders = false 
-let g:moonlight_disable_background = false
+let g:moonlight_italic_comments = v:true
+let g:moonlight_italic_keywords = v:true
+let g:moonlight_italic_functions = v:true
+let g:moonlight_italic_variables = v:false
+let g:moonlight_contrast = v:true
+let g:moonlight_borders = v:false 
+let g:moonlight_disable_background = v:false
 
 -- Load the colorsheme
 colorscheme moonlight


### PR DESCRIPTION
Hello. I've changed the booleans in the readme to reflect neovim's syntax for inserting booleans in vim-script. As written before this config would trigger:

`E121: Undefined variable: true`
`E15:  Invalid epression: true`