### PR TITLE
Fix link to the correct WhichKey plugin in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ added to NeoVim like built-in LSP and [TreeSitter](https://github.com/nvim-trees
     + [NERDTree](https://github.com/preservim/nerdtree)
     + [vim-which-key](https://github.com/liuchengxu/vim-which-key)
     + [Indent-Blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim)
-    + [WhichKey](https://github.com/liuchengxu/vim-which-key)
+    + [WhichKey](https://github.com/folke/which-key.nvim)
     + [Dashboard](https://github.com/glepnir/dashboard-nvim)
     + [BufferLine](https://github.com/akinsho/nvim-bufferline.lua)
     + [Lualine](https://github.com/hoob3rt/lualine.nvim)


### PR DESCRIPTION
There are two "which key" plugins which point to the same place. I think the second should point to https://github.com/folke/which-key.nvim.